### PR TITLE
only run tests on production branch push/pull_request

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -136,7 +136,15 @@ runs:
       shell: bash
       working-directory: repository
       run: |
-        if [ ${{ inputs.skipTests }} = true ]; then echo 'skipping tests'; else npm run test; fi;
+        if [ ${{ steps.variables.outputs.branch }} = production ]; then \
+          if [ ${{ inputs.skipTests }} = true ]; then \
+            echo 'skipping tests due to skipTests flag'; 
+          else \
+            npm run test; 
+          fi;
+        else \
+          echo 'skipping tests for ${{ steps.variables.outputs.branch }} branch'; \
+        fi;
     
     - name: Snapfu Recs Sync
       shell: bash


### PR DESCRIPTION
![Screen Shot 2022-02-16 at 3 29 19 PM](https://user-images.githubusercontent.com/13966707/154351676-4feb78c2-30b1-40ba-97b4-5ee99274d10c.png)

The screenshot shows an audit of which steps run for `push` and `pull_request` triggers. 
This change purposes to only run `npm run test` on the `production` branch for both triggers. 