### PR TITLE
Multi site template sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,12 @@ The `skipLighthouse` input parameter is optional. If set to `true`, the action w
 ### skipPublish
 The `skipPublish` input parameter is optional. If set to `true`, the action will not publish to the CDN.
 
+### secrets
+The `secrets` input parameter should be provided if the project contains multiple siteIds in package.json
+
+It is expected to be encoded using `toJSON`
+
+```yml
+with:
+  secrets: \${{ toJSON(secrets) }}
+```

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,9 @@ inputs:
   GITHUB_BOT_TOKEN:
     description: 'Github user PAT token for posting lighthouse results in pull request comments'
     required: false
+  secrets:
+    description: 'Secrets encoded via toJSON. Expected if project has multiple siteIds in package.json. Expects repository secret for each key (ie. `WEBSITE_SECRET_KEY_${siteId}`)'
+    required: false
 
 runs:
   using: "composite"
@@ -77,9 +80,33 @@ runs:
         fi;
         echo "::set-output name=branch::$branch"
         echo "Using branch: $branch"
-        siteId=`jq -r '.searchspring.siteId' < package.json`
-        echo "::set-output name=siteId::$siteId"
-        echo "Using siteId: $siteId"
+        
+        secrets=`echo "${{ toJSON(inputs.secrets) }}"`;
+        echo "::set-output name=secrets::$secrets";
+        echo "Using secrets: $secrets";
+
+        siteId_Type=`jq -r '.searchspring.siteId | type' < package.json`;
+        echo "::set-output name=siteId_Type::$siteId_Type"; \
+
+        if [ $siteId_Type = 'string' ]; then \
+          echo "siteId is a string"; \
+          siteId=`jq -r '.searchspring.siteId' < package.json`; \
+          echo "::set-output name=siteId::$siteId"; \
+          echo "Using siteId: $siteId"; \
+        elif [ $siteId_Type = 'object' ]; then \
+          echo "siteId is an object"; \
+          siteIds=`jq -r '.searchspring.siteId | keys | join(",")' < package.json`; \
+          echo "::set-output name=siteIds::$siteIds"; \
+          echo "Using siteIds: $siteIds"; \
+
+          siteNames=`jq -r '[.searchspring.siteId[].name] | join(",")' < package.json`; \
+          echo "::set-output name=siteNames::$siteNames"; \
+          echo "Using siteNames: $siteNames"; \
+        else \
+          echo "Cannot determine project siteId from package.json"; \
+          exit 1; \
+        fi;
+
         pullRequestID=${{ github.event.pull_request.number }}
         echo "::set-output name=pullRequestID::$pullRequestID"
         echo "Using pullRequestID: $pullRequestID"
@@ -89,22 +116,6 @@ runs:
         startTime=`date -u +%s`
         echo "::set-output name=startTime::$startTime"
         echo "Using startTime: $startTime"
-    
-    - name: Authenticate siteId and secretKey
-      id: authenticate
-      shell: bash
-      working-directory: repository
-      run: |
-        if curl https://smc-config-api.kube.searchspring.io/api/customer/${{ steps.variables.outputs.siteId }}/verify \
-        -X POST \
-        -d '{"name":"${{ steps.variables.outputs.repository }}"}' \
-        -H "Authorization: ${{ inputs.secretKey }}" \
-        -H "accept: application/json" -H "User-Agent:" \
-        | jq .message \
-        | grep -q 'success'; \
-        then echo 'siteId matches account secretKey!'; \
-        else echo 'Authentication failed! Please ensure siteId, secretKey and repository name are correct.'; exit 1; \
-        fi;
 
     - name: Setup Node
       id: setup-node
@@ -113,6 +124,20 @@ runs:
         node-version: 16
         registry-url: 'https://npm.pkg.github.com'
         scope: '@searchspring'
+
+    - name: Authenticate siteId and secretKey
+      id: authenticate
+      shell: bash
+      run: |
+        npm install
+        node scripts/smc/verify.js \
+          --siteId_Type "${{ steps.variables.outputs.siteId_Type }}" \
+          --siteId "${{ steps.variables.outputs.siteId }}" \
+          --repository "${{ steps.variables.outputs.repository }}" \
+          --secretKey "${{ inputs.secretKey }}" \
+          --siteIds "${{ steps.variables.outputs.siteIds }}" \
+          --siteNames "${{ steps.variables.outputs.siteNames }}" \
+          --secrets-ci '${{ steps.variables.outputs.secrets }}';
 
     - name: Cache node_modules
       id: cache
@@ -136,7 +161,6 @@ runs:
         NODE_AUTH_TOKEN: ${{ inputs.NODE_AUTH_TOKEN }}
       run: |
         npm install
-        npm install -g snapfu
 
     - name: Build Bundle
       id: build
@@ -176,8 +200,12 @@ runs:
       shell: bash
       working-directory: repository
       run: |
+        npm install -g "https://github.com/searchspring/snapfu.git#recs-multi-site" # TODO remove this
+
         if [ ${{ steps.variables.outputs.branch }} = production ]; then \
-          snapfu recs sync --secret-key ${{ inputs.secretKey }}; \
+          snapfu recs sync \
+            --secret-key "${{ inputs.secretKey }}" \
+            --secrets-ci '${{ steps.variables.outputs.secrets }}';
         else \
           echo 'skipping snapfu recs sync for ${{ steps.variables.outputs.branch }} branch'; \
         fi; \
@@ -236,8 +264,18 @@ runs:
         if [ "${{ github.event_name }}" = "pull_request" ]; then \
           echo "skipping upload of 'dist' and 'public' directories to S3 for pull_request action triggers"; \
         else \
-          aws s3 sync --cache-control max-age=1800 --acl public-read dist s3://${{ inputs.aws-s3-bucket-name }}/${{ steps.variables.outputs.siteId }}/${{ steps.variables.outputs.branch }}
-          aws s3 sync --cache-control max-age=1800 --acl public-read public s3://${{ inputs.aws-s3-bucket-name }}/${{ steps.variables.outputs.siteId }}/${{ steps.variables.outputs.branch }}
+          if [ '${{ steps.variables.outputs.siteId_Type }}' = 'string' ]; then \
+            aws s3 sync --cache-control max-age=1800 --acl public-read dist s3://${{ inputs.aws-s3-bucket-name }}/${{ steps.variables.outputs.siteId }}/${{ steps.variables.outputs.branch }}
+            aws s3 sync --cache-control max-age=1800 --acl public-read public s3://${{ inputs.aws-s3-bucket-name }}/${{ steps.variables.outputs.siteId }}/${{ steps.variables.outputs.branch }}
+          elif [ '${{ steps.variables.outputs.siteId_Type }}' = 'object' ]; then \
+            echo "${{ steps.variables.outputs.siteIds }}" | tr , '\n' | while read siteId
+              do
+                echo "Copying files to S3 for siteId $siteId"
+                aws s3 sync --cache-control max-age=1800 --acl public-read dist s3://${{ inputs.aws-s3-bucket-name }}/$siteId/${{ steps.variables.outputs.branch }}
+                aws s3 sync --cache-control max-age=1800 --acl public-read public s3://${{ inputs.aws-s3-bucket-name }}/$siteId/${{ steps.variables.outputs.branch }}
+              done;
+          fi;
+
         fi;
         if [ -f tests/lighthouse/runs/manifest.json ]; then aws s3 sync --acl public-read tests/lighthouse/runs s3://${{ inputs.aws-s3-bucket-name }}/${{ steps.variables.outputs.siteId }}/.lighthouse/${{ steps.variables.outputs.branch }}; fi;
 
@@ -248,35 +286,52 @@ runs:
       env:
         AWS_MAX_ATTEMPTS: 9
       run: |
-        if [ ${{ steps.variables.outputs.branch }} = production ]; then \
-          aws cloudfront create-invalidation --distribution-id ${{ inputs.aws-cloudfront-distribution-id }} --paths "/${{ steps.variables.outputs.siteId }}/*"
-        else \
-          aws cloudfront create-invalidation --distribution-id ${{ inputs.aws-cloudfront-distribution-id }} --paths "/${{ steps.variables.outputs.siteId }}/${{ steps.variables.outputs.branch }}/*"
-          if [ -f tests/lighthouse/runs/manifest.json ]; then aws cloudfront create-invalidation --distribution-id ${{inputs.aws-cloudfront-distribution-id }} --paths "/${{ steps.variables.outputs.siteId }}/.lighthouse/${{ steps.variables.outputs.branch }}/manifest.json"; fi;
+        if [ ${{ steps.variables.outputs.branch }} = production ]; then
+          if [ '${{ steps.variables.outputs.siteId_Type }}' = 'string' ]; then
+            aws cloudfront create-invalidation --distribution-id ${{ inputs.aws-cloudfront-distribution-id }} --paths "/${{ steps.variables.outputs.siteId }}/*"
+          elif [ '${{ steps.variables.outputs.siteId_Type }}' = 'object' ]; then
+            echo "${{ steps.variables.outputs.siteIds }}" | tr , '\n' | while read siteId
+              do
+                echo "Invalidating files for siteId $siteId"
+                aws cloudfront create-invalidation --distribution-id ${{ inputs.aws-cloudfront-distribution-id }} --paths "/$siteId/*"
+              done
+          fi
+        else
+          if [ '${{ steps.variables.outputs.siteId_Type }}' = 'string' ]; then
+            aws cloudfront create-invalidation --distribution-id ${{ inputs.aws-cloudfront-distribution-id }} --paths "/${{ steps.variables.outputs.siteId }}/${{ steps.variables.outputs.branch }}/*"
+            if [ -f tests/lighthouse/runs/manifest.json ]; then aws cloudfront create-invalidation --distribution-id ${{inputs.aws-cloudfront-distribution-id }} --paths "/${{ steps.variables.outputs.siteId }}/.lighthouse/${{ steps.variables.outputs.branch }}/manifest.json"; fi
+          elif [ '${{ steps.variables.outputs.siteId_Type }}' = 'object' ]; then
+            echo "${{ steps.variables.outputs.siteIds }}" | tr , '\n' | while read siteId
+              do
+                echo "Invalidating files for siteId $siteId on branch ${{ steps.variables.outputs.branch }}"
+                aws cloudfront create-invalidation --distribution-id ${{ inputs.aws-cloudfront-distribution-id }} --paths "/$siteId/${{ steps.variables.outputs.branch }}/*"
+                if [ -f tests/lighthouse/runs/manifest.json ]; then aws cloudfront create-invalidation --distribution-id ${{inputs.aws-cloudfront-distribution-id }} --paths "/$siteId/.lighthouse/${{ steps.variables.outputs.branch }}/manifest.json"; fi
+              done
+          fi
         fi
 
-    - run: |
-        npx -y jjo \
-          timestamp=$(date -u +"%FT%TZ" | tr -d '\n') \
-          type=snap-action \
-          data=$(npx -y jjo \
-            conclusion=${{ github.action_status }} \
-            duration=$(expr $(date -u +%s) - ${{ steps.variables.outputs.startTime }} ) \
-            repository=${{ steps.variables.outputs.repository }} \
-            repositoryOwner=${{ github.repository_owner }} \
-            branch=${{ steps.variables.outputs.branch }} \
-            baseRef=${{ github.base_ref }} \
-            actor=${{ github.actor }} \
-            eventName=${{ github.event_name }} \
-            job=${{ github.job }} \
-            url='https://github.com/${{ github.repository_owner }}/${{ steps.variables.outputs.repository }}/actions/runs/${{ github.run_id }}' \
-            runAttempt=${{ github.run_attempt }} \
-            failedStep='${{ steps.checkout-repo.conclusion == 'Failure' && 'checkout-repo' || steps.configure-aws.conclusion == 'Failure' && 'configure-aws' || steps.variables.conclusion == 'Failure' && 'variables' || steps.authenticate.conclusion == 'Failure' && 'authenticate' || steps.setup-node.conclusion == 'Failure' && 'setup-node' || steps.cache.conclusion == 'Failure' && 'cache' || steps.install.conclusion == 'Failure' && 'install' || steps.build.conclusion == 'Failure' && 'build' || steps.test.conclusion == 'Failure' && 'test' || steps.snapfu-recs-sync.conclusion == 'Failure' && 'snapfu-recs-sync' || steps.lighthouse.conclusion == 'Failure' && 'lighthouse' || steps.pr-comment.conclusion == 'Failure' && 'pr-comment' || steps.s3-upload.conclusion == 'Failure' && 's3-upload' || steps.lighthouse-metrics.conclusion == 'Failure' && 'lighthouse-metrics' || steps.invalidation.conclusion == 'Failure' && 'invalidation' || steps.metrics.conclusion == 'Failure' && 'metrics' || ''}}' \
-          ) \
-        > SnapAction-${{ steps.variables.outputs.repository }}-${{ github.event_name }}-$(date -u +"%Y_%m_%d_%H%M").json && \
-        cat ./SnapAction*.json && \
-        aws s3 cp --region us-east-1 ./SnapAction*.json s3://datawarehouse-stage/team-metrics-import/
-      id: metrics
-      shell: bash
-      if: always()
+    # - run: |
+    #     npx -y jjo \
+    #       timestamp=$(date -u +"%FT%TZ" | tr -d '\n') \
+    #       type=snap-action \
+    #       data=$(npx -y jjo \
+    #         conclusion=${{ github.action_status }} \
+    #         duration=$(expr $(date -u +%s) - ${{ steps.variables.outputs.startTime }} ) \
+    #         repository=${{ steps.variables.outputs.repository }} \
+    #         repositoryOwner=${{ github.repository_owner }} \
+    #         branch=${{ steps.variables.outputs.branch }} \
+    #         baseRef=${{ github.base_ref }} \
+    #         actor=${{ github.actor }} \
+    #         eventName=${{ github.event_name }} \
+    #         job=${{ github.job }} \
+    #         url='https://github.com/${{ github.repository_owner }}/${{ steps.variables.outputs.repository }}/actions/runs/${{ github.run_id }}' \
+    #         runAttempt=${{ github.run_attempt }} \
+    #         failedStep='${{ steps.checkout-repo.conclusion == 'Failure' && 'checkout-repo' || steps.configure-aws.conclusion == 'Failure' && 'configure-aws' || steps.variables.conclusion == 'Failure' && 'variables' || steps.authenticate.conclusion == 'Failure' && 'authenticate' || steps.setup-node.conclusion == 'Failure' && 'setup-node' || steps.cache.conclusion == 'Failure' && 'cache' || steps.install.conclusion == 'Failure' && 'install' || steps.build.conclusion == 'Failure' && 'build' || steps.test.conclusion == 'Failure' && 'test' || steps.snapfu-recs-sync.conclusion == 'Failure' && 'snapfu-recs-sync' || steps.lighthouse.conclusion == 'Failure' && 'lighthouse' || steps.pr-comment.conclusion == 'Failure' && 'pr-comment' || steps.s3-upload.conclusion == 'Failure' && 's3-upload' || steps.lighthouse-metrics.conclusion == 'Failure' && 'lighthouse-metrics' || steps.invalidation.conclusion == 'Failure' && 'invalidation' || steps.metrics.conclusion == 'Failure' && 'metrics' || ''}}' \
+    #       ) \
+    #     > SnapAction-${{ steps.variables.outputs.repository }}-${{ github.event_name }}-$(date -u +"%Y_%m_%d_%H%M").json && \
+    #     cat ./SnapAction*.json && \
+    #     aws s3 cp --region us-east-1 ./SnapAction*.json s3://datawarehouse-stage/team-metrics-import/
+    #   id: metrics
+    #   shell: bash
+    #   if: always()
     

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
   },
   "homepage": "https://github.com/searchspring/snap-action#readme",
   "dependencies": {
+    "@actions/core": "^1.9.0",
     "@actions/github": "^5.0.3",
-    "minimist": "^1.2.6"
+    "minimist": "^1.2.6",
+    "node-fetch": "^3.2.6",
+    "snapfu": "^1.0.22"
   }
 }

--- a/scripts/smc/verify.js
+++ b/scripts/smc/verify.js
@@ -29,9 +29,8 @@ const verify = (siteId, name, secretKey) => {
     try {
         const argv = minimist(process.argv.slice(2),  { '--': true });
 
-        if(argv['siteId_Type'] !== 'string' || argv['siteId_Type'] !== 'object') {
+        if(argv['siteId_Type'] !== 'string' && argv['siteId_Type'] !== 'object') {
             console.log("Verify script requires 'siteId_Type' parameter with values either 'string' (single site) or 'object' (multi site)")
-            console.log("argv['siteId_Type']", argv['siteId_Type'])
             exit(1);
         }
         if(!argv['siteId_Type'] === 'string' && (!argv['siteId'] || !argv['repository'] || !argv['secretKey'])) {

--- a/scripts/smc/verify.js
+++ b/scripts/smc/verify.js
@@ -1,0 +1,121 @@
+const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
+const exit = require('process').exit;
+const minimist = require('minimist');
+
+const verify = (siteId, name, secretKey) => {
+    return new Promise(async (resolve, _) => {
+        const body = { name };
+        const response = await fetch(`https://smc-config-api.kube.searchspring.io/api/customer/${siteId}/verify`, {
+            method: 'POST',
+            body: JSON.stringify(body),
+            headers: {
+                'accept': 'application/json',
+                'User-Agent': '',
+                'Authorization': `${secretKey}`
+            }
+        });
+        const data = await response.json();
+        if(data.message === 'success') {
+            console.log(`Authentication successful for siteId ${siteId}`)
+            resolve(true)
+        } else {
+            console.log(`Authentication failed for siteId ${siteId}`)
+            resolve(false)
+        }
+    });
+}
+
+(async function () {
+    try {
+        const argv = minimist(process.argv.slice(2),  { '--': true });
+
+        if(!argv['siteId_Type'] || !argv['siteId_Type'] !== 'string' || !argv['siteId_Type'] !== 'object') {
+            console.log("Verify script requires 'siteId_Type' parameter with values either 'string' (single site) or 'object' (multi site)")
+            exit(1);
+        }
+        if(!argv['siteId_Type'] === 'string' && (!argv['siteId'] || !argv['repository'] || !argv['secretKey'])) {
+            console.log("Verify script requires 'siteId', 'repository' and 'secretKey' parameter")
+            exit(1);
+        }
+        if(!argv['siteId_Type'] === 'object' && (!argv['siteIds'] || !argv['siteNames'] || !argv['secrets-ci'])) {
+            console.log("Verify script requires 'siteId', 'repository' and 'secrets-ci' parameter")
+            exit(1);
+        }
+
+        let authFailed = false;
+        if(argv.siteId_Type === 'string') {
+            // single site
+            const siteId = argv.siteId;
+            const name = argv.repository;
+            const secretKey = argv.secretKey;
+
+            const success = await verify(siteId, name, secretKey);
+            if(!success) {
+                authFailed = true;
+            }
+        } else if (argv.siteId_Type === 'object') {
+            // multi site
+            const siteIds = argv.siteIds.split(',').filter(a => a);
+            const siteNames = argv.siteNames.split(',').filter(a => a);
+
+            if(siteIds.length !== siteNames.length) {
+                console.log("The amount of siteIds and siteNames does not match")
+                exit(1);
+            }
+            
+            let secretsData;
+            try {
+                const jsonSerializingCharacter = argv['secrets-ci'].slice(1,2);
+                const secretsUnserialized = argv['secrets-ci'].split(`${jsonSerializingCharacter} "`).join('"').split(`"${jsonSerializingCharacter}}`).join('"}');
+                secretsData = JSON.parse(secretsUnserialized)
+            } catch(e) {
+                console.log("Could not parse secrets");
+                exit(1);
+            }
+
+            for (let index = 0; index < siteIds.length; index++) {
+                const siteId = siteIds[index];
+                const name = siteNames[index];
+                const secretKey = secretsData[`WEBSITE_SECRET_KEY_${siteId.toUpperCase()}`] || secretsData[`WEBSITE_SECRET_KEY_${siteId}`] || secretsData[`WEBSITE_SECRET_KEY_${siteId.toLowerCase()}`];
+                if(!secretKey) {
+                    console.log(`
+Could not find Github secret 'WEBSITE_SECRET_KEY_${siteId.toUpperCase()}' in 'secrets' input.
+It can be added by running 'snapfu secrets add' in the project's directory locally, 
+or added manual in the project's repository secrets. 
+The value can be obtained in the Searchspring Management Console.
+Then ensure that you are providing 'secrets' when running the action. ie:
+jobs:
+  Publish:
+    runs-on: ubuntu-latest
+    name: Snap Action
+    steps:
+      - name: Checkout action
+        uses: actions/checkout@v2
+        with:
+          repository: searchspring/snap-action
+      - name: Run @searchspring/snap-action
+        uses: ./
+        with:
+          secrets: \${{ toJSON(secrets) }}
+          ...
+`);
+                    exit(1);
+                }
+
+                const success = await verify(siteId, name, secretKey);
+                if(!success) {
+                    authFailed = true;
+                }
+            }
+        }
+
+        if(authFailed) {
+            exit(1);
+        }
+        exit(0);
+    } catch (err) {
+        console.error('unable to process verify file');
+        console.error(err);
+        exit(1);
+    }
+})();

--- a/scripts/smc/verify.js
+++ b/scripts/smc/verify.js
@@ -31,6 +31,7 @@ const verify = (siteId, name, secretKey) => {
 
         if(argv['siteId_Type'] !== 'string' || argv['siteId_Type'] !== 'object') {
             console.log("Verify script requires 'siteId_Type' parameter with values either 'string' (single site) or 'object' (multi site)")
+            console.log("argv['siteId_Type']", argv['siteId_Type'])
             exit(1);
         }
         if(!argv['siteId_Type'] === 'string' && (!argv['siteId'] || !argv['repository'] || !argv['secretKey'])) {

--- a/scripts/smc/verify.js
+++ b/scripts/smc/verify.js
@@ -29,7 +29,7 @@ const verify = (siteId, name, secretKey) => {
     try {
         const argv = minimist(process.argv.slice(2),  { '--': true });
 
-        if(!argv['siteId_Type'] || !argv['siteId_Type'] !== 'string' || !argv['siteId_Type'] !== 'object') {
+        if(argv['siteId_Type'] !== 'string' || argv['siteId_Type'] !== 'object') {
             console.log("Verify script requires 'siteId_Type' parameter with values either 'string' (single site) or 'object' (multi site)")
             exit(1);
         }


### PR DESCRIPTION
Multi site example: https://github.com/searchspring-implementations/snap.searchspring.io/runs/7305555372?check_suite_focus=true

Single site example: https://github.com/searchspring-implementations/snap.searchspring.io/runs/7305670051?check_suite_focus=true

Those two runs are using the corresponding snapfu branch 'recs-multi-site' which I've since removed since it shouldn't be part of this deployment. ie.
```
npm install -g "https://github.com/searchspring/snapfu.git#recs-multi-site"
```
I also bumped the snapfu version here so this should be deployed after `"snapfu": "^1.0.23"` has been released
