### PR TITLE
sanitize commit message by moving it to an intermediate env var

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -168,6 +168,8 @@ runs:
       id: start-metrics
       if: ${{ steps.variables.outputs.isSelfHosted == 'true' }}
       shell: bash
+      env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       run: |
         # Start time metric used in snapp-updater action status, Should only run on self-hosted
         node scripts/metrics/updater.js \
@@ -181,7 +183,7 @@ runs:
           --conclusion "" \
           --duration "" \
           --failedStep "" \
-          --commitMessage "${{ github.event.head_commit.message }}" \
+          --commitMessage "$COMMIT_MESSAGE" \
           --url "https://github.com/${{ github.repository_owner }}/${{ steps.variables.outputs.repository }}/actions/runs/${{ github.run_id }}" \
           --secrets-ci '${{ steps.variables.outputs.secrets }}';
 
@@ -287,6 +289,8 @@ runs:
       if: ${{ contains(steps.variables.outputs.packageJSONVersion, '.') && steps.variables.outputs.branch == 'production' }}
       shell: bash
       working-directory: repository
+      env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       run: |
         git config user.name searchspring-machine
         git config user.email machine@searchspring.com
@@ -311,7 +315,7 @@ runs:
         fi
 
         if [ "${{ contains(github.event.head_commit.message,'from searchspring-implementations/updater/revert/') }}" == "true" ]; then
-          tagToDelete=$(node ./../scripts/tag/getTag.js --tags "$(git tag -l)" --commitMessage "${{ github.event.head_commit.message }}")
+          tagToDelete=$(node ./../scripts/tag/getTag.js --tags "$(git tag -l)" --commitMessage "$COMMIT_MESSAGE")
           git push --delete origin $tagToDelete
         fi
 
@@ -446,13 +450,15 @@ runs:
       id: metrics
       shell: bash
       if: always()
+      env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       run: |
         duration="$(($(date -u +%s)-${{ steps.variables.outputs.startTime }}))"
 
         if [ '${{ steps.variables.outputs.awsCreds }}' == '' ]; then
           echo "Skipping final metric because one of the following inputs has not been provided: aws-access-key-id, aws-secret-access-key, aws-cloudfront-distribution-id, aws-s3-bucket-name"
         else 
-          patchId=$(node scripts/utils/patchId.js --branch "${{ steps.variables.outputs.branch }}" --commitMessage "${{ github.event.head_commit.message }}")
+          patchId=$(node scripts/utils/patchId.js --branch "${{ steps.variables.outputs.branch }}" --commitMessage "$COMMIT_MESSAGE")
           npx -y jjo \
             timestamp=$(date -u +"%FT%TZ" | tr -d '\n') \
             type=snap-action \
@@ -497,7 +503,7 @@ runs:
             --conclusion "${{ github.action_status }}" \
             --duration "$duration" \
             --failedStep "${{ steps.checkout-repo.conclusion == 'Failure' && 'checkout-repo' || steps.configure-aws.conclusion == 'Failure' && 'configure-aws' || steps.variables.conclusion == 'Failure' && 'variables' || steps.authenticate.conclusion == 'Failure' && 'authenticate' || steps.setup-node.conclusion == 'Failure' && 'setup-node' || steps.cache.conclusion == 'Failure' && 'cache' || steps.install.conclusion == 'Failure' && 'install' || steps.build.conclusion == 'Failure' && 'build' || steps.test.conclusion == 'Failure' && 'test' || steps.snapfu-recs-sync.conclusion == 'Failure' && 'snapfu-recs-sync' || steps.lighthouse.conclusion == 'Failure' && 'lighthouse' || steps.tag.conclusion == 'Failure' && 'tag' || steps.pr-comment.conclusion == 'Failure' && 'pr-comment' || steps.s3-upload.conclusion == 'Failure' && 's3-upload' || steps.lighthouse-metrics.conclusion == 'Failure' && 'lighthouse-metrics' || steps.invalidation.conclusion == 'Failure' && 'invalidation' || steps.metrics.conclusion == 'Failure' && 'metrics' || steps.start-metrics.conclusion == 'Failure' && 'start-metrics' || ''}}" \
-            --commitMessage "${{ github.event.head_commit.message }}" \
+            --commitMessage "$COMMIT_MESSAGE" \
             --url "https://github.com/${{ github.repository_owner }}/${{ steps.variables.outputs.repository }}/actions/runs/${{ github.run_id }}" \
             --secrets-ci '${{ steps.variables.outputs.secrets }}';
         fi;


### PR DESCRIPTION
Sanitizing the commit message by moving it to an intermediate environment variable as mentioned in this doc:

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable

Found from: https://github.com/orgs/community/discussions/27065#discussioncomment-3798970